### PR TITLE
Fix ffsend binary link, bump ffsend to v0.2.59

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 FROM debian:stable-slim
 
 ## ffsend version
-ENV FFSEND_VERSION=0.2.58
+ENV FFSEND_VERSION=0.2.59
 
 RUN \
   apt-get update -qq&& \
   apt-get install -y -qq \
     curl && \
-  curl -OL https://github.com/timvisee/ffsend/releases/download/v0.2.58/ffsend-v${FFSEND_VERSION}-linux-x64-static && \
+  curl -OL https://github.com/timvisee/ffsend/releases/download/v${FFSEND_VERSION}/ffsend-v${FFSEND_VERSION}-linux-x64-static && \
   mv ./ffsend-* ./ffsend && \
   chmod a+x ./ffsend && \
   mv ./ffsend /usr/local/bin/ && \


### PR DESCRIPTION
This fixes the `ffsend` binary link, it includes the version number twice, only one of these used the version variable before.

It also bumps `ffsend` to `v0.2.59`. This is useful because it now automatically archives multiple files or directories with a random name, without outputting an error like before.